### PR TITLE
Fix a spelling mistake

### DIFF
--- a/src/sass/lg-thumbnail.scss
+++ b/src/sass/lg-thumbnail.scss
@@ -85,7 +85,7 @@
         }
     }
 
-    .lg-toogle-thumb {
+    .lg-toggle-thumb {
         background-color: $lg-thumb-toggle-bg;
         border-radius: $lg-border-radius-base $lg-border-radius-base 0 0;
         color: $lg-thumb-toggle-color;


### PR DESCRIPTION
'toogle' should be spelled as 'toggle'

This PR contains the SASS changes

Documentation changes: #18 
JS changes: https://github.com/sachinchoolur/lg-thumbnail.js/pull/1
