### PR TITLE
Add an option to disable the toolbar

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -84,6 +84,7 @@ var defaults = {
 
     iframeMaxWidth: '100%',
 
+    toolbar: true,
     download: true,
     counter: true,
     appendCounterTo: '.lg-toolbar',
@@ -285,6 +286,7 @@ Plugin.prototype.structure = function() {
     var controls = '';
     var i = 0;
     var subHtmlCont = '';
+    var toolbar = '';
     var template;
     var _this = this;
 
@@ -308,12 +310,16 @@ Plugin.prototype.structure = function() {
         subHtmlCont = '<div class="lg-sub-html"></div>';
     }
 
+    if (this.s.toolbar) {
+        toolbar = '<div class="lg-toolbar group">' +
+            '<span class="lg-close lg-icon"></span>' +
+            '</div>';
+    }
+
     template = '<div class="lg-outer ' + this.s.addClass + ' ' + this.s.startClass + '">' +
         '<div class="lg" style="width:' + this.s.width + '; height:' + this.s.height + '">' +
         '<div class="lg-inner">' + list + '</div>' +
-        '<div class="lg-toolbar group">' +
-        '<span class="lg-close lg-icon"></span>' +
-        '</div>' +
+        toolbar +
         controls +
         subHtmlCont +
         '</div>' +


### PR DESCRIPTION
I would like to propose adding an option to disable the toolbar.

It will currently break if any elements try to add to the toolbar, so those will need to be disabled as well.

`counter`, `autoplayControls` and `download` will need to be disabled in order to use the option.

Should I also add some error messages to the user in these cases?

Documentation changes: #22 
