### PR TITLE
Do not wait for backdrop to appear before loading image

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -369,11 +369,11 @@ Plugin.prototype.structure = function() {
         utils.setVendor(inner, 'TransitionDuration', this.s.speed + 'ms');
     }
 
-    utils.addClass(document.querySelector('.lg-backdrop'), 'in');
 
     setTimeout(function() {
+        utils.addClass(document.querySelector('.lg-backdrop'), 'in');
         utils.addClass(_this.outer, 'lg-visible');
-    }, this.s.backdropDuration);
+    }, 0);
 
     if (this.s.download) {
         this.outer.querySelector('.lg-toolbar').insertAdjacentHTML('beforeend', '<a id="lg-download" target="_blank" download class="lg-download lg-icon"></a>');
@@ -910,7 +910,7 @@ Plugin.prototype.slide = function(index, fromTouch, fromThumb) {
             }, this.s.speed);
 
         } else {
-            _this.loadContent(index, true, _this.s.backdropDuration);
+            _this.loadContent(index, true, 0);
 
             _this.lgBusy = false;
             utils.trigger(_this.el, 'onAfterSlide', {


### PR DESCRIPTION
I noticed that the image does not load before the backdrop has transitioned in.
If using a higher backdropDuration, this looks odd, since a black screen will fade in before the image is displayed.

This change loads the image instantly, which allows for the backdrop to appear slower than the image.

It also fixes an issue where the backdrop only transitions out, and appears instantly when transitioning in.
