### PR TITLE
Ensure that URLs point to the correct repository

### DIFF
--- a/.banner
+++ b/.banner
@@ -1,6 +1,6 @@
 /**!
  * <%= pkg.name %> | <%= pkg.version %> | <%= moment().format('MMMM Do YYYY') %>
- * http://sachinchoolur.github.io/lightGallery/
+ * http://sachinchoolur.github.io/lightgallery.js/
  * Copyright (c) 2016 Sachin N; 
  * @license Apache 2.0 
  */

--- a/src/fonts/lg.svg
+++ b/src/fonts/lg.svg
@@ -8,7 +8,7 @@
 	"fontFamily": "lg",
 	"majorVersion": 1,
 	"minorVersion": 0,
-	"fontURL": "https://github.com/sachinchoolur/lightGallery",
+	"fontURL": "https://github.com/sachinchoolur/lightgallery.js",
 	"copyright": "sachin",
 	"license": "MLT",
 	"licenseURL": "http://opensource.org/licenses/MIT",


### PR DESCRIPTION
A few URLs within comments and metadata point to [the jQuery lightGallery repo](https://github.com/sachinchoolur/lightGallery) instead of [the zero-dependency version's repo](https://github.com/sachinchoolur/lightgallery.js). This led me on a bit of a wild goose chase today, so I'm hoping that fixing this will avoid that happening to anyone else. 😛 

Since these changes only apply to comments and metadata, there should be no changes to functionality or compatibility.

I haven't updated any files in the `dist` directory, as per the contribution guidelines. I also haven't updated any files in the `demo` directory, but there are a few in there that will need updating.
