### PR TITLE
Update jsDelivr links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ npm install lightgallery.js
 
 ### CDN
 
-http://www.jsdelivr.com/projects/lightgallery.js
+https://cdn.jsdelivr.net/npm/lightgallery.js@latest/dist/js/lightgallery.js
 
 ### Download from GitHub
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/lightgallery.js.

Feel free to ping me if you have any questions regarding this change.