### PR TITLE
Add support for onBeforeDestroy and onAfterDestroy events

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -1327,7 +1327,9 @@ Plugin.prototype.destroy = function(d) {
 
     var _this = this;
 
-    if (!d) {
+    if (d) {
+        utils.trigger(_this.el, 'onBeforeDestroy');
+    } else {
         utils.trigger(_this.el, 'onBeforeClose');
     }
 
@@ -1389,7 +1391,9 @@ Plugin.prototype.destroy = function(d) {
                 document.querySelector('.lg-backdrop').parentNode.removeChild(document.querySelector('.lg-backdrop'));
             }
 
-            if (!d) {
+            if (d) {
+                utils.trigger(_this.el, 'onAfterDestroy');
+            } else {
                 utils.trigger(_this.el, 'onCloseAfter');
             }
         } catch (err) {}


### PR DESCRIPTION
This allows you to take actions (like creating a new gallery) only after the gallery has been fully destroyed