### PR TITLE
Correct spelling mistake in thumbnail section

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -328,11 +328,11 @@ lightGallery(document.getElementById('lightgallery'), {
                             </section>
                             <section class="doc mrb50">
                                 <h3 class="anchor-title mrb15" id="lg-thumbnial">
-                                <a href="#lg-thumbnial">Thumbnial plugin</a>
+                                <a href="#lg-thumbnial">Thumbnail plugin</a>
                                 </h3>
                                 <div class="bs-callout bs-callout-danger mrb20">
                                     <h4>Plugin dependency</h4>
-                                    <p>You need to include thumbnials plugin (lg-thumbnail.js) in your document to use the following options.</p>
+                                    <p>You need to include thumbnails plugin (lg-thumbnail.js) in your document to use the following options.</p>
                                 </div>
                                 <table class="table table-bordered">
                                     <thead>


### PR DESCRIPTION
Corrected spelling mistake 'Thumbnial' to 'Thumbnail' on lines 331 and 335