### PR TITLE
Fix for adding disable class and attribute on lg-prev button

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -1057,8 +1057,8 @@ Plugin.prototype.arrowDisable = function(index) {
             prev.removeAttribute('disabled');
             utils.removeClass(prev, 'disabled');
         } else {
-            next.setAttribute('disabled', 'disabled');
-            utils.addClass(next, 'disabled');
+            prev.setAttribute('disabled', 'disabled');
+            utils.addClass(prev, 'disabled');
         }
     }
 };


### PR DESCRIPTION
Fix for adding disable class and attribute on lg-prev button