### PR TITLE
openSlide method

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -209,14 +209,8 @@ Plugin.prototype.init = function() {
 
                     e.preventDefault();
 
-                    utils.trigger(_this.el, 'onBeforeOpen');
+                    _this.openSlide(index, false, true);
 
-                    _this.index = _this.s.index || index;
-
-                    if (!utils.hasClass(document.body, 'lg-on')) {
-                        _this.build(_this.index);
-                        utils.addClass(document.body, 'lg-on');
-                    }
                 });
 
             })(i);

--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -227,6 +227,32 @@ Plugin.prototype.init = function() {
 
 };
 
+Plugin.prototype.openSlide = function(index = 0, goToIfOpen = false, respectSettingsIndex = false) {
+
+    var _this = this;
+    var hasClassLgOn = utils.hasClass(document.body, 'lg-on');
+
+    if (!hasClassLgOn) {
+        utils.trigger(_this.el, 'onBeforeOpen');
+    }
+
+    if (respectSettingsIndex) {
+        _this.index = _this.s.index || index;
+    } else {
+        _this.index = index;
+    }
+
+    if (!hasClassLgOn) {
+        _this.build(_this.index);
+        utils.addClass(document.body, 'lg-on');
+    } else {
+        if (goToIfOpen) {
+            _this.slide(_this.index, false, false);
+        }
+    }
+
+};
+
 Plugin.prototype.build = function(index) {
 
     var _this = this;


### PR DESCRIPTION
Sometimes it is necessary to link to a specific slide from elsewhere in the page, not just from the slide itself. For example if you had a gallery with 10 pictures and a video, a link with the text of "view video" would need to open the gallery directly on the video, not at the default index.

The [slide()](https://sachinchoolur.github.io/lightgallery.js/docs/api.html#methods) method from the documentation only works after lightgallery has initialised, and therefore isn't suitable.

It is possible to get the gallery open to a slide by executing:
`window.lgData[el.getAttribute('lg-uid')].index = 2;`
`window.lgData[el.getAttribute('lg-uid')].build(2);`
However this doesn't select the current slide in the thumbnail plugin correctly, nor does it trigger the onBeforeOpen event.

By moving the code from the item "click" event to it's own method we can then call it directly to open to a specific slide, for example:
`window.lgData[el.getAttribute('lg-uid')].openSlide(2)`

As well as slide (index) there are 2 other parameters on the method to define:
- if the gallery is already open, should it browse to the slide index given (potentially interrupting the user)
- if the gallery should prefer the index from settings over the slide index provided

I have set default parameter values for what I think will be the majority use case. I have also left the triggering of event "onBeforeOpen" to be _before_ the setting of the index property, to prevent breaking changes to anyone's listeners.