### PR TITLE
Namespace group class to prevent interference

### DIFF
--- a/src/css/lightgallery.css
+++ b/src/css/lightgallery.css
@@ -885,17 +885,17 @@ body:not(.lg-from-hash) .lg-outer.lg-start-zoom .lg-item.lg-complete .lg-object 
   content: "\e903";
 }
 
-.group {
+.lg-group {
   *zoom: 1;
 }
 
-.group:before, .group:after {
+.lg-group:before, .lg-group:after {
   display: table;
   content: "";
   line-height: 0;
 }
 
-.group:after {
+.lg-group:after {
   clear: both;
 }
 

--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -336,7 +336,7 @@ Plugin.prototype.structure = function() {
     template = '<div tabindex="-1" aria-modal="true" ' + ariaLabelledby + ' ' + ariaDescribedby + ' role="dialog" class="lg-outer ' + this.s.addClass + ' ' + this.s.startClass + '">' +
         '<div class="lg" style="width:' + this.s.width + '; height:' + this.s.height + '">' +
         '<div class="lg-inner">' + list + '</div>' +
-        '<div class="lg-toolbar group">' +
+        '<div class="lg-toolbar lg-group">' +
         '<button type="button" aria-label="Close gallery" class="lg-close lg-icon"></button>' +
         '</div>' +
         controls +

--- a/src/sass/lightgallery.scss
+++ b/src/sass/lightgallery.scss
@@ -13,17 +13,17 @@
 @import "lg-rotate";
 
 // Clearfix
-.group {
+.lg-group {
     *zoom: 1;
 }
 
-.group:before, .group:after {
+.lg-group:before, .lg-group:after {
     display: table;
     content: "";
     line-height: 0;
 }
 
-.group:after {
+.lg-group:after {
     clear: both;
 }
 


### PR DESCRIPTION
Group was the only non-namespaced class. It interferes with Tailwind for example (https://tailwindcss.com/docs/pseudo-class-variants/#group-hover).